### PR TITLE
[feat/api] API 공통 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,8 @@ module.exports = {
     },
   },
   rules: {
-    "@typescript-eslint/no-redeclare": 'off'
+    "@typescript-eslint/no-redeclare": 'off',
+    "import/prefer-default-export": 'off',
   },
   extends: [
     'plugin:react/recommended',

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,6 @@ module.exports = {
     '^@pages(.*)$':  '<rootDir>/src/pages$1',
     '^@store(.*)$':  '<rootDir>/src/store$1',
     '^@utils(.*)$':  '<rootDir>/src/utils$1',
-
+    '^@api(.*)$':  '<rootDir>/src/api$1',
   }
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     }
   },
   "dependencies": {
+    "axios": "^0.21.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-router-dom": "^5.2.0",

--- a/src/api/controllers/Question.ts
+++ b/src/api/controllers/Question.ts
@@ -1,5 +1,5 @@
 import { request, makeOptions } from './utils';
-import config from './config';
+import { QUESTION_URL } from './config';
 
 interface IQuestionModel {
   title: string;
@@ -9,7 +9,7 @@ interface IQuestionModel {
 
 const createQuestion = async (questionInfo: IQuestionModel): Promise<any> => {
   try {
-    const url = config.QUESTION_URL;
+    const url = QUESTION_URL;
     const body = {
       ...questionInfo,
     };

--- a/src/api/controllers/Question.ts
+++ b/src/api/controllers/Question.ts
@@ -1,0 +1,27 @@
+import { request, makeOptions } from './utils';
+import config from './config';
+
+interface IQuestionModel {
+  title: string;
+  content: string;
+  emoji: string;
+}
+
+const createQuestion = async (questionInfo: IQuestionModel): Promise<any> => {
+  try {
+    const url = config.QUESTION_URL;
+    const body = {
+      ...questionInfo,
+    };
+    const options = await makeOptions('GET', body);
+    const data = await request(url, options);
+    return data;
+  } catch (e) {
+    console.error(e);
+    return e.message;
+  }
+};
+
+export {
+  createQuestion,
+};

--- a/src/api/controllers/Question.ts
+++ b/src/api/controllers/Question.ts
@@ -1,13 +1,13 @@
 import { request, makeOptions } from './utils';
 import { QUESTION_URL } from './config';
 
-interface IQuestionModel {
+type TQuestionModel {
   title: string;
   content: string;
   emoji: string;
 }
 
-const createQuestion = async (questionInfo: IQuestionModel): Promise<any> => {
+const createQuestion = async (questionInfo: TQuestionModel): Promise<any> => {
   try {
     const url = QUESTION_URL;
     const body = {

--- a/src/api/controllers/config.ts
+++ b/src/api/controllers/config.ts
@@ -1,6 +1,6 @@
-const BASE_URL = 'https://jjalbot.com/api/jjals';
-// const QUESTION_PATH = '/question';
+const BASE_URL = 'https://localhost:8080';
+const QUESTION_PATH = '/question';
 
-const QUESTION_URL = `${BASE_URL}`;
+const QUESTION_URL = `${BASE_URL}${QUESTION_PATH}`;
 
 export default { QUESTION_URL };

--- a/src/api/controllers/config.ts
+++ b/src/api/controllers/config.ts
@@ -1,0 +1,6 @@
+const BASE_URL = 'https://jjalbot.com/api/jjals';
+// const QUESTION_PATH = '/question';
+
+const QUESTION_URL = `${BASE_URL}`;
+
+export default { QUESTION_URL };

--- a/src/api/controllers/config.ts
+++ b/src/api/controllers/config.ts
@@ -3,4 +3,4 @@ const QUESTION_PATH = '/question';
 
 const QUESTION_URL = `${BASE_URL}${QUESTION_PATH}`;
 
-export default { QUESTION_URL };
+export { QUESTION_URL };

--- a/src/api/controllers/utils.ts
+++ b/src/api/controllers/utils.ts
@@ -1,0 +1,62 @@
+import axios from 'axios';
+
+type TRequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+type TRestApiHeaders = {
+  'content-type': string,
+  Authorization?: string,
+};
+
+type TApiData = {
+  data: any;
+  message: string | number;
+  isSuccess: boolean;
+};
+
+type TApiSuccess = TApiData;
+type TApiFail = TApiData;
+
+interface IRestApiOptions {
+  method: TRequestMethod;
+  headers: TRestApiHeaders;
+  params?: string;
+}
+
+export type TApiReturn = TApiSuccess | TApiFail;
+export type TFetchReturnType = Promise<TApiReturn>;
+
+const parseResult = (res: TApiReturn): any => {
+  if (!res.isSuccess) {
+    throw new Error('res.isSuccess is false');
+  }
+  return res.data;
+};
+
+const makeOptions = (method: TRequestMethod, params: any): IRestApiOptions => ({
+  method,
+  headers: {
+    'content-type': 'application/json',
+  },
+  params,
+});
+
+const request = async (url: string, options: IRestApiOptions): TFetchReturnType => {
+  try {
+    const res = await axios({
+      method: options.method,
+      url,
+      params: options.params,
+      headers: options.headers,
+    });
+    const data: any = await parseResult(res.data);
+    return data;
+  } catch (e) {
+    console.error('@request api error', e);
+    return e.message;
+  }
+};
+
+export {
+  makeOptions,
+  request,
+};

--- a/src/api/controllers/utils.ts
+++ b/src/api/controllers/utils.ts
@@ -9,30 +9,30 @@ type TRestApiHeaders = {
 
 type TApiData = {
   data: any;
-  message: string | number;
+  message: string;
   isSuccess: boolean;
 };
 
 type TApiSuccess = TApiData;
 type TApiFail = TApiData;
 
-interface IRestApiOptions {
+type TRestApiOptions = {
   method: TRequestMethod;
   headers: TRestApiHeaders;
   params?: string;
 }
 
 export type TApiReturn = TApiSuccess | TApiFail;
-export type TFetchReturnType = Promise<TApiReturn>;
+export type TFetchReturnType = Promise<Pick<TApiReturn, 'data'> | Error>;
 
-const parseResult = (res: TApiReturn): any => {
+const parseResult = (res: TApiReturn): Pick<TApiReturn, 'data'> | Error => {
   if (!res.isSuccess) {
     throw new Error('res.isSuccess is false');
   }
   return res.data;
 };
 
-const makeOptions = (method: TRequestMethod, params: any): IRestApiOptions => ({
+const makeOptions = (method: TRequestMethod, params: any): TRestApiOptions => ({
   method,
   headers: {
     'content-type': 'application/json',
@@ -40,15 +40,13 @@ const makeOptions = (method: TRequestMethod, params: any): IRestApiOptions => ({
   params,
 });
 
-const request = async (url: string, options: IRestApiOptions): TFetchReturnType => {
+const request = async (url: string, options: TRestApiOptions): TFetchReturnType => {
   try {
     const res = await axios({
-      method: options.method,
+      ...options,
       url,
-      params: options.params,
-      headers: options.headers,
     });
-    const data: any = await parseResult(res.data);
+    const data = parseResult(res.data);
     return data;
   } catch (e) {
     console.error('@request api error', e);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,3 @@
+import { createQuestion } from './controllers/Question';
+
+export default { createQuestion };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,3 @@
 import { createQuestion } from './controllers/Question';
 
-export default { createQuestion };
+export { createQuestion };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
       "@pages": ["pages"],
       "@pages/*": ["pages/*"],
       "@store/*": ["store/*"],
-      "@utils/*": ["utils/*"]
+      "@utils/*": ["utils/*"],
+      "@api/*": ["api/*"]
     }
   },
   "include": ["./src"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     '@store': path.resolve(__dirname, './src/store'),
     '@utils': path.resolve(__dirname, './src/utils'),
     '@styles': path.resolve(__dirname, './src/styles'),
+    '@api': path.resolve(__dirname, './src/api'),
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
## API 공통 구현
- eslint rule 추가 : `"import/prefer-default-export": 'off'`
  - export default만 쓰도록 권장하는 lint
  - util이나 api의 경우 export를 쓰는게 권장되는 형태도 있어 off 처리
- alias추가: `@api`
- `axios` 추가
- api 공통 모듈 구현
  - 서버와 맞추는 과정에서 수정 필요
  - controller 분리 작업 완료하였고 리뷰 필요