### PR TITLE
[lint/default props] 현재는 많이 사용하지 않는 default props 규칙 제거

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
   rules: {
     "@typescript-eslint/no-redeclare": 'off',
     "import/prefer-default-export": 'off',
+    "react/require-default-props": 'off' // https://twitter.com/dan_abramov/status/1133878326358171650
   },
   extends: [
     'plugin:react/recommended',


### PR DESCRIPTION
현재는 많이 사용되고 있지 않는 default-props 규칙을 제거하였습니다.

해당 근거로 https://twitter.com/dan_abramov/status/1133878326358171650

deprecated 대상입니다.